### PR TITLE
Fix Windows ARM64 builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,8 @@ builds:
       - linux
       - windows
       - darwin
+      - freebsd
+      - netbsd
     goarch:
       - amd64
       - arm64

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kgaughan/nxtp
 
-go 1.13
+go 1.18


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the build configuration to include support for FreeBSD and NetBSD, and upgrades the Go version from 1.13 to 1.18.

- **Build**:
    - Added support for FreeBSD and NetBSD in the build configuration.
    - Updated Go version from 1.13 to 1.18 in go.mod.

<!-- Generated by sourcery-ai[bot]: end summary -->