### PR TITLE
Add latest tag to future images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,6 +49,7 @@ archives:
 dockers:
   - image_templates:
       - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE }}:{{ .Tag }}"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE }}:latest"
     skip_push: auto
     use: buildx
     dockerfile: Dockerfile


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the .goreleaser.yaml configuration to include a 'latest' tag for future Docker images, ensuring that the most recent image is always tagged as 'latest'.

- **Deployment**:
    - Added 'latest' tag to Docker images in the .goreleaser.yaml configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->