### PR TITLE
Bundle the built-in tzdata

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,7 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
     tags:
       - netgo
+      - timetzdata
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 nxtp: main.go zones.go
-	CGO_ENABLED=0 go build -tags netgo -trimpath -ldflags '-s -w'
+	CGO_ENABLED=0 go build -tags netgo,timetzdata -trimpath -ldflags '-s -w'
 
 zones.go: tools/windowsZones.xml
 	tools/generatezones.py $^ > $@


### PR DESCRIPTION
This is just in case somebody wants to deploy this somewhere without timezone data installed. It'll act as a fallback.