### PR TITLE
Homebrew support and an OpenBSD build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,7 @@ builds:
       - darwin
       - freebsd
       - netbsd
+      - openbsd
     goarch:
       - amd64
       - arm64
@@ -27,6 +28,22 @@ builds:
     tags:
       - netgo
       - timetzdata
+
+brews:
+  - name: nxtp
+    ids:
+      - archives
+    homepage: "https://github.com/kgaughan/nxtp"
+    repository:
+      owner: kgaughan
+      name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: Keith Gaughan
+      email: k@stereochro.me
+    description: " A Network neXt Time Protocol (NXTP) client and server"
+    license: "MIT"
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add OpenBSD as a supported build target and introduce Homebrew support by configuring a Homebrew formula in the build system.

New Features:
- Add support for building the project on OpenBSD.

Build:
- Introduce Homebrew support by adding a configuration for creating a Homebrew formula.

<!-- Generated by sourcery-ai[bot]: end summary -->